### PR TITLE
Python 3 compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README
+include README.rst
 include CHANGES.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [egg_info]
-#tag_build = dev
-#tag_date = true
+tag_build = dev
+tag_date = true
 
 [aliases]
 release = egg_info -RDb '' register bdist_egg sdist upload

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-f = open('README', 'r')
+f = open('README.rst', 'r')
 try:
     long_desc = f.read()
 finally:
@@ -12,7 +12,7 @@ requires = ['Sphinx>=0.6']
 
 setup(
     name='sphinxcontrib-email',
-    version='0.1',
+    version='0.2',
     url='http://bitbucket.org/birkenfeld/sphinx-contrib',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-email',
     license='BSD',

--- a/sphinxcontrib/email.py
+++ b/sphinxcontrib/email.py
@@ -10,9 +10,14 @@ from docutils import nodes
 # a BSD license.
 
 import re
-import string
 
-rot_13_trans = string.maketrans(
+try:
+    maketrans = ''.maketrans
+except AttributeError:
+    # fallback for Python 2
+    from string import maketrans
+
+rot_13_trans = maketrans(
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
     'NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm'
 )
@@ -57,8 +62,12 @@ def email_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     """
     Role to obfuscate e-mail addresses.
     """
-    print 123456789, text, '\n\n'
-    text = text.decode('utf-8').encode('utf-8')
+    try:
+        text = text.decode('utf-8').encode('utf-8')
+    except AttributeError:
+        # fallback for Python 3
+        pass
+
     # Handle addresses of the form "Name <name@domain.org>"
     if '<' in text and '>' in text:
         name, email = text.split('<')


### PR DESCRIPTION
Fix string compatibility between Python 2 and 3
Python 3 removed the decode() function from the string module, because all strings are unicode in Python 3.
This unbreaks sphinxcontrib/email.py for Python 3.


https://bitbucket.org/birkenfeld/sphinx-contrib/pull-requests/129/email-python-3-compatibility/diff