### PR TITLE
fix: link badges to appropiate targets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,32 @@
 sphinxcontrib-email
 ===================
 
-|badge:pypi-version| |badge:py-versions|
-|badge:pre-commit| |badge:pre-commit.ci|
-|badge:black| |badge:prettier|
+.. image:: https://img.shields.io/pypi/v/sphinxcontrib-email?color=blue&logo=python&logoColor=white
+   :target: https://pypi.org/project/sphinxcontrib-email/
+   :alt: Latest PyPI version
 
-.. |badge:pypi-version| image:: https://img.shields.io/pypi/v/sphinxcontrib-scm.svg
-   :target: https://pypi.org/project/sphinxcontrib-scm
-   :alt: [Latest PyPI version]
-.. |badge:py-versions| image:: https://img.shields.io/pypi/pyversions/sphinxcontrib-scm.svg
-   :target: https://pypi.org/project/sphinxcontrib-scm
-   :alt: [Supported Python versions]
-.. |badge:pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen.svg?logo=pre-commit&logoColor=white
+.. image:: https://img.shields.io/pypi/pyversions/sphinxcontrib-email?color=blue&logo=python&logoColor=white
+   :target: https://pypi.org/project/sphinxcontrib-email/
+   :alt: Supported Python versions
+
+.. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen.svg?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
-   :alt: [pre-commit: enabled]
-.. |badge:pre-commit.ci| image:: https://results.pre-commit.ci/badge/github/sphinx-contrib/scm/master.svg
-   :target: https://results.pre-commit.ci/latest/github/sphinx-contrib/scm/master
-   :alt: [pre-commit.ci status]
-.. |badge:black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: [Code style: black]
-.. |badge:prettier| image:: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
-   :target: https://github.com/prettier/prettier
-   :alt: [Code style: prettier]
+   :alt: pre-commit: enabled
 
+.. image:: https://results.pre-commit.ci/latest/github/sphinx-contrib/email/master.svg
+   :target: https://results.pre-commit.ci/latest/github/sphinx-contrib/email/master
+   :alt: pre-commit.ci status
+
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+   :alt: Code style: black
+
+.. image:: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
+   :target: https://github.com/prettier/prettier
+   :alt: Code style: prettier
 
 This package provides ``sphinxcontrib.email``, an email obfuscator for
 Sphinx-based documentation.
-
 
 Installation
 ------------
@@ -36,7 +35,6 @@ Installation
 
 Support for python 3.6 will be dropped after its EOL on 2021-12-23.
 
-
 Configuration
 -------------
 
@@ -44,8 +42,7 @@ Configuration
 
    .. code::
 
-      extensions = [ 'sphinxcontrib.email' ]
-
+      extensions = ['sphinxcontrib.email']
 
 Usage
 -----
@@ -60,7 +57,6 @@ In ``conf.py``, set
    email_automode = True
 
 to automatically obfuscate all ``mailto`` links.
-
 
 Manual Mode
 ^^^^^^^^^^^


### PR DESCRIPTION
FIx #15 

I also removed the specific references, they are only used in the readme, so let's use the image directive directly instead